### PR TITLE
hyperscale type must have hyperscale storage_type

### DIFF
--- a/src/clc/APIv2/server.py
+++ b/src/clc/APIv2/server.py
@@ -451,9 +451,8 @@ class Server(object):
 			if not memory and group.Defaults("memory"):  memory = group.Defaults("memory")
 			elif not memory:  raise(clc.CLCException("No default Memory defined"))
 		if not description:  description = name
-		if type.lower() not in ("standard","hyperscale"):  raise(clc.CLCException("Invalid type"))
-		if storage_type.lower() not in ("standard","premium"):  raise(clc.CLCException("Invalid storage_type"))
-		if storage_type.lower() == "premium" and type.lower() == "hyperscale":  raise(clc.CLCException("Invalid type/storage_type combo"))
+                if type.lower() == "standard" and storage_type.lower() not in ("standard","premium"):  raise(clc.CLCException("Invalid storage_type"))
+                if type.lower() == "hyperscale" and storage_type.lower() != "hyperscale"  raise(clc.CLCException("Invalid type/storage_type combo"))
 		if ttl and ttl<=3600: raise(clc.CLCException("ttl must be greater than 3600 seconds"))
 		if ttl: ttl = clc.v2.time_utils.SecondsToZuluTS(int(time.time())+ttl)
 		# TODO - validate custom_fields as a list of dicts with an id and a value key


### PR DESCRIPTION
This should allow for hyperscale servers to be created.

From the docs
> For standard servers, whether to use standard or premium storage. If not provided, will default to
> premium storage. For hyperscale servers, storage type must be hyperscale.
