### PR TITLE
Updated how the GetAll() method reference data elements of the Policy…

### DIFF
--- a/src/clc/APIv2/anti_affinity.py
+++ b/src/clc/APIv2/anti_affinity.py
@@ -36,10 +36,14 @@ class AntiAffinity(object):
 		if not alias:  alias = clc.v2.Account.GetAlias()
 
 		policies = []
-		for r in clc.v2.API.Call('GET','antiAffinityPolicies/%s' % alias,{}):
-			if location and r['location'].lower()!=location.lower():  continue
-			servers = [obj['id'] for obj in r['links'] if obj['rel'] == "server"]
-			policies.append(AntiAffinity(id=r['id'],name=r['name'],location=r['location'],servers=servers))
+		policy_resp = clc.v2.API.Call('GET','antiAffinityPolicies/%s' % alias,{})
+		for k in policy_resp:
+			r_val = policy_resp[k]
+			for r in r_val:
+				if r.get('location'):
+					if location and r['location'].lower()!=location.lower():  continue
+					servers = [obj['id'] for obj in r['links'] if obj['rel'] == "server"]
+					policies.append(AntiAffinity(id=r['id'],name=r['name'],location=r['location'],servers=servers))
 
 		return(policies)
 


### PR DESCRIPTION
… object.

The implementation for  the GetAll() method is not longer valid for the current policy data structure when attempting to retrieve the location data item from the Policy object.  This pull request is for an update to the anti-affinity module to reference that attribute without errors.