### PR TITLE
Added the capability to provide the api with a custom request session…

### DIFF
--- a/README_PYTHON_APIV1_SDK.md
+++ b/README_PYTHON_APIV1_SDK.md
@@ -24,6 +24,21 @@ All API calls require authentication using your API V1 credentials.
 >>> clc.v1.SetCredentials("api_key","api_password")
 ```
 
+### Custom Http Settings
+Custom http settings can be provided to the SDK through an optional requests session object.  Once provided, this
+session is stored by the SDK and used for all API requests. Requests sessions can be used to specify proxies or to 
+provide site-specific http headers:
+
+```python
+>>> import requests
+>>> ses = requests.Session()
+>>> ses.proxies = {
+  "http": "http://10.10.1.10:3128",
+  "https": "http://10.10.1.10:1080",
+}
+>>> ses.headers.update({"X-PROXY-AUTH": "12345abcdef"})
+>>> clc.SetRequestsSession(ses)
+```
 
 ### Accounts
 

--- a/README_PYTHON_APIV2_SDK.md
+++ b/README_PYTHON_APIV2_SDK.md
@@ -115,7 +115,21 @@ Login itself is made lazily when the first API call requiring credentials is iss
 >>> clc.v2.SetCredentials("username","password")
 ```
 
+## Custom Http Settings
+Custom http settings can be provided to the SDK through an optional requests session object.  Once provided, this
+session is stored by the SDK and used for all API requests. Requests sessions can be used to specify proxies or to 
+provide site-specific http headers:
 
+```python
+>>> import requests
+>>> ses = requests.Session()
+>>> ses.proxies = {
+  "http": "http://10.10.1.10:3128",
+  "https": "http://10.10.1.10:1080",
+}
+>>> ses.headers.update({"X-PROXY-AUTH": "12345abcdef"})
+>>> clc.SetRequestsSession(ses)
+```
 
 ## Account
 

--- a/src/clc/APIv1/api.py
+++ b/src/clc/APIv1/api.py
@@ -52,9 +52,12 @@ class API():
 
 		clc._LOGINS += 1
 
-		r = requests.post("%s%s" % (clc.defaults.ENDPOINT_URL_V1,"/Auth/logon"),
-						  params={'APIKey': clc.v1.V1_API_KEY, 'Password': clc.v1.V1_API_PASSWD},
-						  verify=API._ResourcePath('clc/cacert.pem'))
+		session = clc._REQUESTS_SESSION
+
+		r = session.request("POST",
+                            "%s%s" % (clc.defaults.ENDPOINT_URL_V1,"/Auth/logon"),
+                            params={'APIKey': clc.v1.V1_API_KEY, 'Password': clc.v1.V1_API_PASSWD},
+                            verify=API._ResourcePath('clc/cacert.pem'))
 
 		try:
 			resp = xml.etree.ElementTree.fromstring(r.text)
@@ -66,6 +69,7 @@ class API():
 				raise(Exception("Error logging into V1 API.  Status code %s. %s" % (resp.attrib['StatusCode'],resp.attrib['Message'])))
 		except:
 			if clc.args:  clc.v1.output.Status('ERROR',3,'Error logging into v1 API.  Server response %s' % (r.status_code))
+
 
 
 	@staticmethod
@@ -81,11 +85,13 @@ class API():
 		"""
 		if not clc._LOGIN_COOKIE_V1:  API._Login()
 
-		r = requests.request(method,"%s%s/JSON" % (clc.defaults.ENDPOINT_URL_V1,url), 
-							 params=payload, 
-							 headers={'content-type': 'application/json'},
-							 cookies=clc._LOGIN_COOKIE_V1,
-							 verify=API._ResourcePath('clc/cacert.pem'))
+		session = clc._REQUESTS_SESSION
+		session.headers.update({'content-type': 'application/json'})
+
+		r = session.request(method,"%s%s/JSON" % (clc.defaults.ENDPOINT_URL_V1,url),
+                             params=payload,
+                             cookies=clc._LOGIN_COOKIE_V1,
+                             verify=API._ResourcePath('clc/cacert.pem'))
 
 		if debug:
 			API._DebugRequest(request=requests.Request(method,"%s%s/JSON" % (clc.defaults.ENDPOINT_URL_V1,url),

--- a/src/clc/__init__.py
+++ b/src/clc/__init__.py
@@ -19,6 +19,7 @@ API Documentaton v2: https://t3n.zendesk.com/categories/20067994-API-v2-0-Beta-
 import APIv1 as v1
 import APIv2 as v2
 import defaults
+import requests
 
 
 ####### module/object vars #######
@@ -41,10 +42,17 @@ _V1_ENABLED = False
 _V2_ENABLED = False
 _LOGINS = 0
 _BLUEPRINT_FTP_URL = False
+_REQUESTS_SESSION = requests.Session()
 
 _GROUP_MAPPING = {}
 
 LOCATIONS = ['CA1','CA2','CA3','DE1','GB1','GB3','IL1','NY1','UC1','UT1','VA1','WA1']	# point in time snapshot - exec Account.GetLocations for current
+
+def SetRequestsSession(session):
+	"""Provide a custom requests session for the SDK to use when invoking the API"""
+	global _REQUESTS_SESSION
+	_REQUESTS_SESSION = session
+
 
 class CLCException(Exception):
 	pass


### PR DESCRIPTION
Hi Keith... can you take a look at this PR?  We added the ability to provide a sessions object to the SDK so that callers can set things like proxies and custom headers for the http request.  We needed that for some of the functionality we're building into the CLC Ansible modules.  I'm thinking others will need it too.

Let me know what you think.  Thanks, Brian 