### PR TITLE
Fixed group.description bug with the v2 API Response. 

### DIFF
--- a/src/clc/APIv2/group.py
+++ b/src/clc/APIv2/group.py
@@ -144,6 +144,7 @@ class Group(object):
 
 		if key in self.data:  return(self.data[key])
 		elif key in self.data['changeInfo']:  return(self.data['changeInfo'][key])
+		elif key.lower() == 'description': return str()
 		else:  raise(AttributeError("'%s' instance has no attribute '%s'" % (self.__class__.__name__,key)))
 
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 
 setup(
 	name = "clc-sdk",
-	version = "2.26",
+	version = "2.27",
 	packages = find_packages("."),
 
 	install_requires = ['prettytable','clint','argparse','requests'],


### PR DESCRIPTION
Hi Keith...  Can you take a look at this change?  

This fixes a bug we were seeing where the v2 API isn't returning a Description in the payload for Groups, but the Groups.Get function expects one to be there.  This can cause the SDK to throw an AttributeError when searching for a group, if there are groups in the datacenter that don't have a Description set.  My change just returns an empty string if description isn't set, so that we don't fail.

Thanks,
Brian