### PR TITLE
Enhance Datacenter Networks Data

### DIFF
--- a/src/clc/APIv2/datacenter.py
+++ b/src/clc/APIv2/datacenter.py
@@ -104,7 +104,7 @@ class Datacenter:
 
 
 	def Networks(self):
-		return(clc.v2.Networks(networks_lst=self._DeploymentCapabilities()['deployableNetworks']))
+		return(clc.v2.Networks(alias=self.alias, location=self.location))
 
 
 	def Templates(self):

--- a/src/clc/APIv2/datacenter.py
+++ b/src/clc/APIv2/datacenter.py
@@ -1,5 +1,5 @@
 """
-Datacenter related functions.  
+Datacenter related functions.
 
 These datacenter related functions generally align one-for-one with published API calls categorized in the account category
 
@@ -43,7 +43,7 @@ class Datacenter:
 	def __init__(self,location=None,name=None,alias=None):
 		"""Create Datacenter object.
 
-		If parameters are populated then create object location.  
+		If parameters are populated then create object location.
 		Else if only id is supplied issue a Get Policy call
 
 		https://t3n.zendesk.com/entries/31026420-Get-Data-Center-Group
@@ -97,14 +97,17 @@ class Datacenter:
 
 
 	def _DeploymentCapabilities(self,cached=True):
-		if not self.deployment_capabilities or not cached:  
+		if not self.deployment_capabilities or not cached:
 			self.deployment_capabilities = clc.v2.API.Call('GET','datacenters/%s/%s/deploymentCapabilities' % (self.alias,self.location))
 
 		return(self.deployment_capabilities)
 
 
-	def Networks(self):
-		return(clc.v2.Networks(alias=self.alias, location=self.location))
+	def Networks(self, forced_load=False):
+		if forced_load:
+			return(clc.v2.Networks(alias=self.alias, location=self.location))
+		else:
+			return(clc.v2.Networks(networks_lst=self._DeploymentCapabilities()['deployableNetworks']))
 
 
 	def Templates(self):
@@ -120,4 +123,3 @@ class Datacenter:
 
 	def __str__(self):
 		return(self.location)
-

--- a/tests/test_datacenter.py
+++ b/tests/test_datacenter.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python
+
+import mock
+from mock import patch, create_autospec
+import unittest
+from library.datacenter import Datacenter
+import clc as clc_sdk
+
+
+# Written by a non-Python developer
+# Please make me better
+
+class TestClcDatacenter(unittest.TestCase):
+
+    def setUp(self):
+        dcs = {
+            "name": "test_dc_name",
+            "links": [{"rel": "group", "id": "test_group_id", "name": "test_group_name"}]
+        }
+        clc_sdk.v2.API.Call = mock.MagicMock(return_value=dcs)
+        self.test_obj = Datacenter(location="test123", alias="007", )
+
+    def testDefaultConstructor(self):
+        clc_sdk.v2.Account.GetAlias = mock.MagicMock(return_value="mock_alias")
+        clc_sdk.v2.Account.GetLocation = mock.MagicMock(return_value="mock_loc")
+        obj = Datacenter()
+        assert clc_sdk.v2.Account.GetAlias.call_count == 1
+        assert clc_sdk.v2.Account.GetLocation.call_count == 1
+        clc_sdk.v2.API.Call.assert_called_with('GET','datacenters/mock_alias/mock_loc',{'GroupLinks': 'true'})
+        self.assertEqual(obj.id, "mock_loc")
+        self.assertEqual(obj.name, "test_dc_name")
+        self.assertEqual(obj.alias, "mock_alias")
+        self.assertEqual(obj.location, "mock_loc")
+        self.assertEqual(obj.root_group_id, "test_group_id")
+        self.assertEqual(obj.root_group_name, "test_group_name")
+
+    def testConstructorAllArgs(self):
+        clc_sdk.v2.API.Call.assert_called_once_with('GET','datacenters/007/test123',{'GroupLinks': 'true'})
+        self.assertEqual(self.test_obj.id, "test123")
+        self.assertEqual(self.test_obj.name, "test_dc_name")
+        self.assertEqual(self.test_obj.alias, "007")
+        self.assertEqual(self.test_obj.location, "test123")
+        self.assertEqual(self.test_obj.root_group_id, "test_group_id")
+        self.assertEqual(self.test_obj.root_group_name, "test_group_name")
+
+    def testStringify(self):
+        self.assertEqual(str(self.test_obj), "test123")
+
+    def testNetworks(self):
+        clc_sdk.v2.Networks = mock.MagicMock(return_value="hello")
+        clc_sdk.v2.API.Call = mock.MagicMock(return_value={"deployableNetworks": "network_list"})
+        me = self.test_obj.Networks()
+        clc_sdk.v2.Networks.assert_called_once_with(networks_lst="network_list")
+
+    def testNetworksWithForcedLoad(self):
+        clc_sdk.v2.Networks = mock.MagicMock(return_value="hello")
+        me = self.test_obj.Networks(forced_load=True)
+        clc_sdk.v2.Networks.assert_called_once_with(alias="007", location="test123")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request seeks to enrich the data stored in the Networks member of the Datacenter class by replacing the existing _DeploymentCapabilities() call with an implicit call to Networks._Load.  The API called by _Load provides considerably more data than that stored under 'deployableNetworks' and allows for some additional filtering in the Networks class (read: you can search for a network by cidr notation instead of only by id and/or name).

The _DeploymentCapabilties network only contains the account alias, network name, network id, and network type, whereas the GET call in _Load returns all of those fields plus many more.  