### PR TITLE
Secondary nic enhancements

### DIFF
--- a/src/clc/APIv2/server.py
+++ b/src/clc/APIv2/server.py
@@ -391,7 +391,8 @@ class Server(object):
 
 
 	def AddNIC(self,network_id,ip=''):
-		"""Execute an existing Bluerprint package on the server.
+		"""Add a NIC from the provided network to server and, if provided,
+		   assign a provided IP address
 
 		https://www.ctl.io/api-docs/v2/#servers-add-secondary-network
 
@@ -399,7 +400,7 @@ class Server(object):
 		for the package itself.  The UUID parameter is the package ID we need.
 
 		network_id - ID associated with the network to add
-		ip - Explicit IP address to assgin (optional)
+		ip - Explicit IP address to assign (optional)
 
 		Need to reinstantiate the server object after execution completes to see the assigned IP address.
 
@@ -414,6 +415,28 @@ class Server(object):
 		return(clc.v2.Requests(clc.v2.API.Call('POST','servers/%s/%s/networks' % (self.alias,self.id),
 		                                       json.dumps({'networkId': network_id, 'ipAddress': ip})),
 							   alias=self.alias))
+
+	def RemoveNIC(self,network_id):
+		"""Remove the NIC associated with the provided network from the server.
+
+		https://www.ctl.io/api-docs/v2/#servers-remove-secondary-network
+
+		network_id - ID associated with the network to remove
+
+        >>> network = clc.v2.Networks(location="VA1").Get("10.128.166.0/24")
+        >>> clc.v2.Server(alias='BTDI',id='WA1BTDIKRT06'). \
+        		RemoveNIC(network_id=network.id). \
+        		WaitUntilComplete()
+		0
+
+		"""
+
+		return(
+			clc.v2.Requests(
+				clc.v2.API.Call('DELETE','servers/%s/%s/networks/%s'
+					% (self.alias,self.id,network_id)),
+			  alias=self.alias
+	  ))
 
 
 	def GetSnapshots(self):

--- a/tests/library
+++ b/tests/library
@@ -1,1 +1,0 @@
-../src/clc/APIv2

--- a/tests/test_datacenter.py
+++ b/tests/test_datacenter.py
@@ -3,8 +3,8 @@
 import mock
 from mock import patch, create_autospec
 import unittest
-from library.datacenter import Datacenter
 import clc as clc_sdk
+from clc.APIv2 import Datacenter
 
 
 # Written by a non-Python developer

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -3,8 +3,8 @@
 import mock
 from mock import patch, create_autospec
 import unittest
-from library.network import Networks, Network
 import clc as clc_sdk
+from clc.APIv2 import Networks, Network
 
 
 # Written by a non-Python developer
@@ -37,7 +37,7 @@ class TestClcNetwork(unittest.TestCase):
 
     def testGetAttrInData(self):
         self.assertEqual(self.test_obj.field1, "value1")
-        self.assertEqual(self.test_obj.change1, 'changeVal1')
+        self.assertEqual(self.test_obj.changeInfo['change1'], 'changeVal1')
         with self.assertRaises(AttributeError) as ex:
             self.test_obj.does_not_exist
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,193 @@
+#!/usr/bin/python
+
+import mock
+from mock import patch, create_autospec
+import unittest
+import clc as clc_sdk
+from clc.APIv2 import Servers, Server
+
+
+# Python is not my primary language, so if this looks laughably simple,
+# please correct it and make it better
+
+class TestClcServer(unittest.TestCase):
+
+    def setUp(self):
+        clc_sdk.v2.Account.GetAlias = mock.MagicMock(return_value="base_test")
+        self.test_obj = Server(id=12345, server_obj=True)
+
+    def testDefaultConstructor(self):
+        clc_sdk.v2.Account.GetAlias = mock.MagicMock(return_value="default")
+        Server.Refresh = mock.MagicMock()
+        svr = Server(id=42)
+        self.assertEqual(1, clc_sdk.v2.Account.GetAlias.call_count)
+        self.assertEqual(1, Server.Refresh.call_count)
+        self.assertEqual(svr.id, 42)
+
+    def testDefaultContructorFailedRefresh(self):
+        clc_sdk.v2.Account.GetAlias = mock.MagicMock(return_value="default")
+        Server.Refresh = mock.MagicMock(side_effect=self.get_mock_exception(error_code=404))
+        with self.assertRaises(clc_sdk.CLCException):
+            Server(id=42)
+
+    # Lots of _Operation calls; might as well test them
+    def testOperationErrorPath(self):
+        clc_sdk.v2.API.Call = mock.MagicMock(side_effect=self.get_mock_exception(fail_json={'virus':'very yes'}))
+        clc_sdk.v2.Requests = mock.MagicMock()
+        self.test_obj._Operation(operation='whatever')
+        clc_sdk.v2.Requests.assert_called_once_with({'virus':'very yes'},alias='base_test')
+
+    def testOperationHappyPath(self):
+        clc_sdk.v2.API.Call = mock.MagicMock()
+        clc_sdk.v2.Requests = mock.MagicMock()
+        self.test_obj._Operation(operation='whatever')
+        clc_sdk.v2.API.Call.assert_called_once_with('POST','operations/base_test/servers/whatever','["12345"]')
+
+    def testArchive(self):
+        self.test_obj._Operation = mock.MagicMock();
+        self.test_obj.Archive()
+        self.test_obj._Operation.assert_called_once_with('archive')
+
+    def testPause(self):
+        self.test_obj._Operation = mock.MagicMock();
+        self.test_obj.Pause()
+        self.test_obj._Operation.assert_called_once_with('pause')
+
+    def testShutDown(self):
+        self.test_obj._Operation = mock.MagicMock();
+        self.test_obj.ShutDown()
+        self.test_obj._Operation.assert_called_once_with('shutDown')
+
+    def testReboot(self):
+        self.test_obj._Operation = mock.MagicMock();
+        self.test_obj.Reboot()
+        self.test_obj._Operation.assert_called_once_with('reboot')
+
+    def testReset(self):
+        self.test_obj._Operation = mock.MagicMock();
+        self.test_obj.Reset()
+        self.test_obj._Operation.assert_called_once_with('reset')
+
+    def testPowerOff(self):
+        self.test_obj._Operation = mock.MagicMock();
+        self.test_obj.PowerOff()
+        self.test_obj._Operation.assert_called_once_with('powerOff')
+
+    def testPowerOn(self):
+        self.test_obj._Operation = mock.MagicMock();
+        self.test_obj.PowerOn()
+        self.test_obj._Operation.assert_called_once_with('powerOn')
+
+    def testStartMaintenance(self):
+        self.test_obj._Operation = mock.MagicMock();
+        self.test_obj.StartMaintenance()
+        self.test_obj._Operation.assert_called_once_with('startMaintenance')
+
+    def testStopMaintenance(self):
+        self.test_obj._Operation = mock.MagicMock();
+        self.test_obj.StopMaintenance()
+        self.test_obj._Operation.assert_called_once_with('stopMaintenance')
+
+
+    # Begin the endless stream of create tests...
+    #
+    # The ugly part of these is that we can't really test for the output, as we're
+    # simply getting back a requests array without the raw submitted data.  Most
+    # of these tests focus on validating input for exceptions/lack of exceptions
+    def testCreateNoCpuException(self):
+        with patch('clc.v2.Group') as mock_group:
+            fake_group = mock.MagicMock()
+            fake_group.Defaults.return_value = None
+            mock_group.return_value = fake_group
+            with self.assertRaises(clc_sdk.CLCException) as ex:
+                Server.Create(name='x',template='x',group_id='x',network_id='x',alias='x')
+
+        self.assertEqual(str(ex.exception), "No default CPU defined")
+
+
+    def testCreateNoMemoryException(self):
+        with patch('clc.v2.Group') as mock_group:
+            fake_group = mock.MagicMock()
+            fake_group.Defaults.return_value = None
+            mock_group.return_value = fake_group
+            with self.assertRaises(clc_sdk.CLCException) as ex:
+                Server.Create(name='x',template='x',group_id='x',network_id='x',alias='x',cpu=2)
+
+        self.assertEqual(str(ex.exception), "No default Memory defined")
+
+    def testCreateDefaultCpuAndMemory(self):
+        with patch('clc.v2.Group') as mock_group:
+            fake_group = mock.MagicMock()
+            fake_group.Defaults.return_value = 42
+            mock_group.return_value = fake_group
+            clc_sdk.v2.API.Call = mock.MagicMock()
+            clc_sdk.v2.Requests = mock.MagicMock()
+            test = Server.Create(name='x',template='x',group_id='x',network_id='x',alias='x')
+            # No assert -- if it doesn't blow up, it worked.  We hope.
+
+    def testIllegalStorageType(self):
+        with self.assertRaises(clc_sdk.CLCException) as ex:
+            Server.Create(
+                name='x',template='x',group_id='x',network_id='x',alias='x',cpu=2,memory=2,storage_type="kaboom")
+        self.assertEqual(str(ex.exception), "Invalid type/storage_type combo")
+
+    def testHyperscaleWithStandard(self):
+        with self.assertRaises(clc_sdk.CLCException) as ex:
+            Server.Create(
+                name='x',template='x',group_id='x',network_id='x',alias='x',cpu=2,memory=2,
+                type="hyperscale",storage_type="standard")
+        self.assertEqual(str(ex.exception), "Invalid type/storage_type combo")
+
+    def testHyperscaleWithPremium(self):
+        with self.assertRaises(clc_sdk.CLCException) as ex:
+            Server.Create(
+                name='x',template='x',group_id='x',network_id='x',alias='x',cpu=2,memory=2,
+                type="hyperscale",storage_type="premium")
+        self.assertEqual(str(ex.exception), "Invalid type/storage_type combo")
+
+    def testStandardWithHyperscale(self):
+        with self.assertRaises(clc_sdk.CLCException) as ex:
+            Server.Create(
+                name='x',template='x',group_id='x',network_id='x',alias='x',cpu=2,memory=2,
+                type="standard",storage_type="hyperscale")
+        self.assertEqual(str(ex.exception), "Invalid type/storage_type combo")
+
+    def testBadTTL(self):
+        with self.assertRaises(clc_sdk.CLCException) as ex:
+            Server.Create(
+                name='x',template='x',group_id='x',network_id='x',alias='x',cpu=2,memory=2,ttl=10)
+        self.assertEqual(str(ex.exception), "ttl must be greater than 3600 seconds")
+
+    # End endless stream
+
+    def testDelete(self):
+        clc_sdk.v2.Requests = mock.MagicMock()
+        clc_sdk.v2.API.Call = mock.MagicMock()
+        self.test_obj.Delete()
+        clc_sdk.v2.API.Call.assert_called_once_with('DELETE','servers/base_test/12345')
+
+    # def testClone(self):
+    #     p = patch("clc.v2.Server", new=mock.MagicMock())
+    #     Server.Credentials = mock.MagicMock(return_value={'password':'aPassword'})
+
+    #     to_clone = Server(name='cloneme',description='yes',cpu=13,memory=14,group_id=54321,
+    #         alias='clone-alias',storage_type='big',type='small',)
+    #     p.start()
+    #     to_clone.Clone(network_id=24601)
+    #     Server.Create.assert_called_once_with('data')
+    #     print("BRIAN:",output)
+    #     p.stop()
+
+
+    # Static helpers
+    @staticmethod
+    def get_mock_exception(error_code=None, fail_json=None):
+        e = clc_sdk.APIFailedResponse("Fake message")
+        if error_code:
+            e.response_status_code = error_code
+        if fail_json:
+            e.response_json = fail_json
+        return e
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -167,7 +167,7 @@ class TestClcServer(unittest.TestCase):
         self.test_obj.Delete()
         clc_sdk.v2.API.Call.assert_called_once_with('DELETE','servers/base_test/12345')
 
-    # AddNIC tests
+    # *NIC tests
 
     def test_AddNIC_calls_api_when_no_ip_provided(self):
         clc_sdk.v2.Requests = mock.MagicMock()
@@ -189,6 +189,12 @@ class TestClcServer(unittest.TestCase):
             json.dumps({'networkId': 'test_network2', 'ipAddress': '1.2.3.4'})
             )
 
+    def test_RemoveNIC_makes_expected_api_call(self):
+        clc_sdk.v2.Requests = mock.MagicMock()
+        clc_sdk.v2.API.Call = mock.MagicMock()
+        self.test_obj.RemoveNIC(network_id='goodbye_network')
+        clc_sdk.v2.API.Call.assert_called_once_with(
+            'DELETE', 'servers/base_test/12345/networks/goodbye_network')
 
 
     # Static helpers

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+import json
 import mock
 from mock import patch, create_autospec
 import unittest
@@ -166,17 +167,28 @@ class TestClcServer(unittest.TestCase):
         self.test_obj.Delete()
         clc_sdk.v2.API.Call.assert_called_once_with('DELETE','servers/base_test/12345')
 
-    # def testClone(self):
-    #     p = patch("clc.v2.Server", new=mock.MagicMock())
-    #     Server.Credentials = mock.MagicMock(return_value={'password':'aPassword'})
+    # AddNIC tests
 
-    #     to_clone = Server(name='cloneme',description='yes',cpu=13,memory=14,group_id=54321,
-    #         alias='clone-alias',storage_type='big',type='small',)
-    #     p.start()
-    #     to_clone.Clone(network_id=24601)
-    #     Server.Create.assert_called_once_with('data')
-    #     print("BRIAN:",output)
-    #     p.stop()
+    def test_AddNIC_calls_api_when_no_ip_provided(self):
+        clc_sdk.v2.Requests = mock.MagicMock()
+        clc_sdk.v2.API.Call = mock.MagicMock()
+        self.test_obj.AddNIC(network_id='test_network')
+        clc_sdk.v2.API.Call.assert_called_once_with(
+            'POST',
+            'servers/base_test/12345/networks',
+            json.dumps({'networkId': 'test_network', 'ipAddress': ''})
+            )
+
+    def test_AddNIC_calls_api_with_provided_ip(self):
+        clc_sdk.v2.Requests = mock.MagicMock()
+        clc_sdk.v2.API.Call = mock.MagicMock()
+        self.test_obj.AddNIC(network_id='test_network2', ip='1.2.3.4')
+        clc_sdk.v2.API.Call.assert_called_once_with(
+            'POST',
+            'servers/base_test/12345/networks',
+            json.dumps({'networkId': 'test_network2', 'ipAddress': '1.2.3.4'})
+            )
+
 
 
     # Static helpers


### PR DESCRIPTION
81. Adds method to remove secondary nic
5. Adds test coverage for a chunk of the server module
2117. Cleanup of existing unit test suite
3. Cleans up arg validation in Server.create() for readability