### PR TITLE
Networks get bugfix

### DIFF
--- a/src/clc/APIv2/network.py
+++ b/src/clc/APIv2/network.py
@@ -66,9 +66,13 @@ class Networks(object):
 		"""
 
 		for network in self.networks:
-			if network.id == key:  return(network)
-			if network.name == key:  return(network)
-			if network.cidr == key:  return(network)
+			try:
+				if network.id == key:  return(network)
+				if network.name == key:  return(network)
+				if network.cidr == key:  return(network)
+			except:
+				# We ignore malformed records with missing attributes
+				pass
 
 
 class Network(object):

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -190,6 +190,10 @@ class TestClcNetworks(unittest.TestCase):
                 "id": 90210,
                 "cidr": "192.42.10.0/24",
                 "name": "fake_network_three",
+            },
+            {
+                "id": 24601,
+                "name": "snowflake-t3n-network-with-no-cidr-attribute",
             }
         ]
         clc_sdk.v2.API.Call = mock.MagicMock(return_value=mock_output)
@@ -220,6 +224,12 @@ class TestClcNetworks(unittest.TestCase):
 
     def testGetNetworkByCidr(self):
         self.assertEqual(self.test_obj.Get("172.22.10.0/24"), self.test_obj.networks[1])
+
+    def testGetNetworkDoesNotThrowException(self):
+        try:
+            self.test_obj.Get("whatever")
+        except Exception:
+            self.fail("Networks.v2.Get() should not raise an exception")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
There are networks that are returned with missing attributes, which causes the Networks.v2.Get() method to return an exception.  While the networks should ideally have all of the attributes that are specified in the v2 API docs, the SDK should also not asplode.  This PR swallows the missing attribute exception so that things like Ansible server provisioning are not broken if you're unlucky enough to have a malformed network in your account.