### PR TITLE
Add session support to avoid global variable access

### DIFF
--- a/src/clc/APIv2/account.py
+++ b/src/clc/APIv2/account.py
@@ -1,5 +1,5 @@
 """
-Account related functions.  
+Account related functions.
 
 These account related functions generally align one-for-one with published API calls categorized in the account category
 
@@ -32,39 +32,48 @@ import clc
 class Account:
 
 	@staticmethod
-	def GetAlias():  
+	def GetAlias(session=None):
 		"""Return specified alias or if none the alias associated with the provided credentials.
 
 		>>> clc.v2.Account.GetAlias()
 		u'BTDI'
 		"""
+		if session is not None:
+			return session['alias']
+
 		if not clc.ALIAS:  clc.v2.API._Login()
 		return(clc.ALIAS)
 
 
 	@staticmethod
-	def GetLocation():  
+	def GetLocation(session=None):
 		"""Return specified location or if none the default location associated with the provided credentials and alias.
-		
+
 		>>> clc.v2.Account.GetLocation()
 		u'WA1'
 		"""
+		if session is not None:
+			return session['location']
+
 		if not clc.LOCATION:  clc.v2.API._Login()
 		return(clc.LOCATION)
 
 
-	def __init__(self,alias=None):
+	def __init__(self,alias=None,session=None):
 		"""Create account object.
 
 		>>> clc.v2.Account()
 		<clc.APIv2.account.Account instance at 0x1065a2e60>
 
 		"""
+		self.session = session
 
-		if alias:  self.alias = alias
-		else:  self.alias = clc.v2.Account.GetAlias()
+		if alias:
+			self.alias = alias
+		else:
+			self.alias = clc.v2.Account.GetAlias(session=self.session)
 
-		self.data = clc.v2.API.Call('GET','accounts/%s' % (self.alias),{})
+		self.data = clc.v2.API.Call('GET','accounts/%s' % (self.alias),{},session=session)
 
 
 	def ParentAccount(self):
@@ -79,7 +88,7 @@ class Account:
 		None
 		"""
 
-		return(Account(alias=self.data['parentAlias']))
+		return(Account(alias=self.data['parentAlias'], session=self.session))
 
 
 	def PrimaryDatacenter(self):
@@ -92,7 +101,7 @@ class Account:
 
 		"""
 
-		return(clc.v2.Datacenter(alias=self.alias,location=self.data['primaryDataCenter']))
+		return(clc.v2.Datacenter(alias=self.alias,location=self.data['primaryDataCenter'], session=self.session))
 
 
 	def __getattr__(self,var):
@@ -105,6 +114,3 @@ class Account:
 
 	def __str__(self):
 		return(self.data['accountAlias'])
-
-
-

--- a/src/clc/APIv2/anti_affinity.py
+++ b/src/clc/APIv2/anti_affinity.py
@@ -1,5 +1,5 @@
 """
-Anti-affinity related functions.  
+Anti-affinity related functions.
 
 These Anti-affinity related functions generally align one-for-one with published API calls categorized in the account category
 
@@ -25,7 +25,7 @@ import json
 class AntiAffinity(object):
 
 	@staticmethod
-	def GetAll(alias=None,location=None):  
+	def GetAll(alias=None,location=None,session=None):
 		"""Gets a list of anti-affinity policies within a given account.
 
 		https://t3n.zendesk.com/entries/44657214-Get-Anti-Affinity-Policies
@@ -34,36 +34,36 @@ class AntiAffinity(object):
 		[<clc.APIv2.anti_affinity.AntiAffinity object at 0x10c65e910>, <clc.APIv2.anti_affinity.AntiAffinity object at 0x10c65ec90>]
 
 		"""
-		if not alias:  alias = clc.v2.Account.GetAlias()
+		if not alias:  alias = clc.v2.Account.GetAlias(session=session)
 
 		policies = []
-		policy_resp = clc.v2.API.Call('GET','antiAffinityPolicies/%s' % alias,{})
+		policy_resp = clc.v2.API.Call('GET','antiAffinityPolicies/%s' % alias,{},session=session)
 		for k in policy_resp:
 			r_val = policy_resp[k]
 			for r in r_val:
 				if r.get('location'):
 					if location and r['location'].lower()!=location.lower():  continue
 					servers = [obj['id'] for obj in r['links'] if obj['rel'] == "server"]
-					policies.append(AntiAffinity(id=r['id'],name=r['name'],location=r['location'],servers=servers))
+					policies.append(AntiAffinity(id=r['id'],name=r['name'],location=r['location'],servers=servers,session=session))
 
 		return(policies)
 
-	
+
 	@staticmethod
-	def GetLocation(location=None,alias=None):
+	def GetLocation(location=None,alias=None,session=None):
 		"""Returns a list of anti-affinity policies within a specific location.
 
 		>>> clc.v2.AntiAffinity.GetLocation("VA1")
 		[<clc.APIv2.anti_affinity.AntiAffinity object at 0x105eeded0>]
 
 		"""
-		if not location:  location = clc.v2.Account.GetLocation()
+		if not location:  location = clc.v2.Account.GetLocation(session=session)
 
-		return(AntiAffinity.GetAll(alias=alias,location=location))
+		return(AntiAffinity.GetAll(alias=alias,location=location,session=session))
 
 
 	@staticmethod
-	def Create(name,alias=None,location=None):  
+	def Create(name,alias=None,location=None,session=None):
 		"""Creates a new anti-affinity policy within a given account.
 
 		https://t3n.zendesk.com/entries/45042770-Create-Anti-Affinity-Policy
@@ -73,18 +73,19 @@ class AntiAffinity(object):
 
 		"""
 
-		if not alias:  alias = clc.v2.Account.GetAlias()
-		if not location:  location = clc.v2.Account.GetLocation()
+		if not alias:  alias = clc.v2.Account.GetAlias(session=session)
+		if not location:  location = clc.v2.Account.GetLocation(session=session)
 
 		r = clc.v2.API.Call('POST','antiAffinityPolicies/%s' % alias,
-							json.dumps({'name': name, 'location': location}))
-		return(AntiAffinity(id=r['id'],name=r['name'],location=r['location'],servers=[]))
+							json.dumps({'name': name, 'location': location}),
+							session=session)
+		return(AntiAffinity(id=r['id'],name=r['name'],location=r['location'],servers=[],session=session))
 
 
-	def __init__(self,id,alias=None,name=None,location=None,servers=None):
+	def __init__(self,id,alias=None,name=None,location=None,servers=None,session=None):
 		"""Create AntiAffinity object.
 
-		If parameters are populated then create object location.  
+		If parameters are populated then create object location.
 		Else if only id is supplied issue a Get Policy call
 
 		https://t3n.zendesk.com/entries/44658344-Get-Anti-Affinity-Policy
@@ -95,16 +96,17 @@ class AntiAffinity(object):
 		"""
 
 		self.id = id
+		self.session = session
 
 		if alias:  self.alias = alias
-		else:  self.alias = clc.v2.Account.GetAlias()
+		else:  self.alias = clc.v2.Account.GetAlias(session=self.session)
 
 		if name:
 			self.name = name
 			self.location = location
 			self.servers = servers
 		else:
-			r = clc.v2.API.Call('GET','antiAffinityPolicies/%s/%s' % (self.alias,self.id),{})
+			r = clc.v2.API.Call('GET','antiAffinityPolicies/%s/%s' % (self.alias,self.id),{},session=self.session)
 			self.name = r['name']
 			self.location = r['location']
 			self.servers = [obj['id'] for obj in r['links'] if obj['rel'] == "server"]
@@ -119,7 +121,7 @@ class AntiAffinity(object):
 
 		"""
 
-		r = clc.v2.API.Call('PUT','antiAffinityPolicies/%s/%s' % (self.alias,self.id),{'name': name})
+		r = clc.v2.API.Call('PUT','antiAffinityPolicies/%s/%s' % (self.alias,self.id),{'name': name},session=self.session)
 		self.name = name
 
 
@@ -131,9 +133,8 @@ class AntiAffinity(object):
 		>>> a = clc.v2.AntiAffinity.GetLocation("WA1")[0]
 		>>> a.Delete()
 		"""
-		r = clc.v2.API.Call('DELETE','antiAffinityPolicies/%s/%s' % (self.alias,self.id),{})
+		r = clc.v2.API.Call('DELETE','antiAffinityPolicies/%s/%s' % (self.alias,self.id),{},session=self.session)
 
 
 	def __str__(self):
 		pass
-

--- a/src/clc/APIv2/disk.py
+++ b/src/clc/APIv2/disk.py
@@ -1,11 +1,11 @@
 """
-Disk related functions.  
+Disk related functions.
 
 Disks object variables:
 
 Disk object variables:
 
-	disk.id 
+	disk.id
 	disk.partition_paths - list of mounts paths
 	disk.size - disk size in GB
 
@@ -20,11 +20,12 @@ import clc
 
 class Disks(object):
 
-	def __init__(self,server,disks_lst):
+	def __init__(self,server,disks_lst,session=None):
 		self.server = server
 		self.disks = []
+		self.session = session
 		for disk in disks_lst:
-			self.disks.append(Disk(id=disk['id'],parent=self,disk_obj=disk))
+			self.disks.append(Disk(id=disk['id'],parent=self,disk_obj=disk,session=self.session))
 
 
 	def Get(self,key):
@@ -74,25 +75,28 @@ class Disks(object):
 
 		disk_set = [{'diskId': o.id, 'sizeGB': o.size} for o in self.disks]
 		disk_set.append({'sizeGB': size, 'type': type, 'path': path})
-		self.disks.append(Disk(id=int(time.time()),parent=self,disk_obj={'sizeGB': size,'partitionPaths': [path]}))
+		self.disks.append(Disk(id=int(time.time()),parent=self,disk_obj={'sizeGB': size,'partitionPaths': [path]},session=self.session))
 
 		self.size = size
 		self.server.dirty = True
 		return(clc.v2.Requests(clc.v2.API.Call('PATCH','servers/%s/%s' % (self.server.alias,self.server.id),
-		                                       json.dumps([{"op": "set", "member": "disks", "value": disk_set}])),
-							   alias=self.server.alias))
+		                                       json.dumps([{"op": "set", "member": "disks", "value": disk_set}]),
+											   session=self.session),
+							   alias=self.server.alias,
+							   session=self.session))
 
 
 
 class Disk(object):
 
-	def __init__(self,id,parent,disk_obj=None):
+	def __init__(self,id,parent,disk_obj=None,session=None):
 		"""Create Disk object."""
 
 		self.id = id
 		self.parent = parent
 		self.size = disk_obj['sizeGB']
 		self.data = disk_obj
+		self.session = session
 
 
 	def Grow(self,size):
@@ -115,12 +119,14 @@ class Disk(object):
 		disk_set.append({'diskId': self.id, 'sizeGB': self.size})
 		self.parent.server.dirty = True
 		return(clc.v2.Requests(clc.v2.API.Call('PATCH','servers/%s/%s' % (self.parent.server.alias,self.parent.server.id),
-		                                       json.dumps([{"op": "set", "member": "disks", "value": disk_set}])),
-							   alias=self.parent.server.alias))
+		                                       json.dumps([{"op": "set", "member": "disks", "value": disk_set}]),
+											   session=self.session),
+							   alias=self.parent.server.alias,
+							   session=self.session))
 
 
 	def Delete(self):
-		"""Delete disk.  
+		"""Delete disk.
 
 		This request will error if disk is protected and cannot be removed (e.g. a system disk)
 
@@ -133,8 +139,10 @@ class Disk(object):
 		self.parent.disks = [o for o in self.parent.disks if o!=self]
 		self.parent.server.dirty = True
 		return(clc.v2.Requests(clc.v2.API.Call('PATCH','servers/%s/%s' % (self.parent.server.alias,self.parent.server.id),
-		                                       json.dumps([{"op": "set", "member": "disks", "value": disk_set}])),
-							   alias=self.parent.server.alias))
+		                                       json.dumps([{"op": "set", "member": "disks", "value": disk_set}]),
+											   session=self.session),
+							   alias=self.parent.server.alias,
+							   session=self.session))
 
 
 	def __getattr__(self,var):
@@ -146,4 +154,3 @@ class Disk(object):
 
 	def __str__(self):
 		return(self.id)
-

--- a/src/clc/APIv2/template.py
+++ b/src/clc/APIv2/template.py
@@ -1,5 +1,5 @@
 """
-Template related functions.  
+Template related functions.
 
 Templates object variables:
 
@@ -62,4 +62,3 @@ class Template(object):
 
 	def __str__(self):
 		return(self.id)
-

--- a/tests/test_datacenter.py
+++ b/tests/test_datacenter.py
@@ -26,7 +26,7 @@ class TestClcDatacenter(unittest.TestCase):
         obj = Datacenter()
         assert clc_sdk.v2.Account.GetAlias.call_count == 1
         assert clc_sdk.v2.Account.GetLocation.call_count == 1
-        clc_sdk.v2.API.Call.assert_called_with('GET','datacenters/mock_alias/mock_loc',{'GroupLinks': 'true'})
+        clc_sdk.v2.API.Call.assert_called_with('GET','datacenters/mock_alias/mock_loc',{'GroupLinks': 'true'}, session=None)
         self.assertEqual(obj.id, "mock_loc")
         self.assertEqual(obj.name, "test_dc_name")
         self.assertEqual(obj.alias, "mock_alias")
@@ -35,7 +35,7 @@ class TestClcDatacenter(unittest.TestCase):
         self.assertEqual(obj.root_group_name, "test_group_name")
 
     def testConstructorAllArgs(self):
-        clc_sdk.v2.API.Call.assert_called_once_with('GET','datacenters/007/test123',{'GroupLinks': 'true'})
+        clc_sdk.v2.API.Call.assert_called_once_with('GET','datacenters/007/test123',{'GroupLinks': 'true'}, session=None)
         self.assertEqual(self.test_obj.id, "test123")
         self.assertEqual(self.test_obj.name, "test_dc_name")
         self.assertEqual(self.test_obj.alias, "007")
@@ -50,12 +50,12 @@ class TestClcDatacenter(unittest.TestCase):
         clc_sdk.v2.Networks = mock.MagicMock(return_value="hello")
         clc_sdk.v2.API.Call = mock.MagicMock(return_value={"deployableNetworks": "network_list"})
         me = self.test_obj.Networks()
-        clc_sdk.v2.Networks.assert_called_once_with(networks_lst="network_list")
+        clc_sdk.v2.Networks.assert_called_once_with(networks_lst="network_list", session=None)
 
     def testNetworksWithForcedLoad(self):
         clc_sdk.v2.Networks = mock.MagicMock(return_value="hello")
         me = self.test_obj.Networks(forced_load=True)
-        clc_sdk.v2.Networks.assert_called_once_with(alias="007", location="test123")
+        clc_sdk.v2.Networks.assert_called_once_with(alias="007", location="test123", session=None)
 
 
 if __name__ == '__main__':

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -78,8 +78,9 @@ class TestClcNetwork(unittest.TestCase):
         network = Network.Create()
         clc_sdk.v2.API.Call.assert_called_once_with(
             'POST',
-            '/v2-experimental/networks/alias1/location1/claim')
-        clc_sdk.v2.Requests.assert_called_once_with("testing", alias="alias1")
+            '/v2-experimental/networks/alias1/location1/claim',
+            session=None)
+        clc_sdk.v2.Requests.assert_called_once_with("testing", alias="alias1", session=None)
 
     def testCreateNetworkWithAllArgs(self):
         clc_sdk.v2.API.Call = mock.MagicMock(return_value="testing")
@@ -88,8 +89,9 @@ class TestClcNetwork(unittest.TestCase):
         network = Network.Create(alias='mock_alias', location='mock_dc')
         clc_sdk.v2.API.Call.assert_called_once_with(
             'POST',
-            '/v2-experimental/networks/mock_alias/mock_dc/claim')
-        clc_sdk.v2.Requests.assert_called_once_with("testing", alias="mock_alias")
+            '/v2-experimental/networks/mock_alias/mock_dc/claim',
+            session=None)
+        clc_sdk.v2.Requests.assert_called_once_with("testing", alias="mock_alias", session=None)
 
     def testDeleteNetworkGetsAbsentLocation(self):
         clc_sdk.v2.Account.GetLocation = mock.MagicMock(return_value="location1")
@@ -98,7 +100,8 @@ class TestClcNetwork(unittest.TestCase):
         self.test_obj.Delete()
         clc_sdk.v2.API.Call.assert_called_once_with(
             'POST',
-            '/v2-experimental/networks/007/location1/12345/release')
+            '/v2-experimental/networks/007/location1/12345/release',
+            session=None)
 
     def testDeleteNetworkWithAllArgs(self):
         clc_sdk.v2.API.Call = mock.MagicMock()
@@ -106,7 +109,8 @@ class TestClcNetwork(unittest.TestCase):
         self.test_obj.Delete(location='location123')
         clc_sdk.v2.API.Call.assert_called_once_with(
             'POST',
-            '/v2-experimental/networks/007/location123/12345/release')
+            '/v2-experimental/networks/007/location123/12345/release',
+            session=None)
 
     def testUpdateNetworkGetsAbsentLocation(self):
         clc_sdk.v2.Account.GetLocation = mock.MagicMock(return_value="location2")
@@ -118,7 +122,8 @@ class TestClcNetwork(unittest.TestCase):
         clc_sdk.v2.API.Call.assert_called_once_with(
             'PUT',
             '/v2-experimental/networks/007/location2/12345',
-            {'name': name, 'description': self.test_obj.description})
+            {'name': name, 'description': self.test_obj.description},
+            session=None)
 
     def testUpdateNetworkWithAllArgs(self):
         clc_sdk.v2.API.Call = mock.MagicMock()
@@ -130,7 +135,8 @@ class TestClcNetwork(unittest.TestCase):
         clc_sdk.v2.API.Call.assert_called_once_with(
             'PUT',
             '/v2-experimental/networks/007/location456/12345',
-            {'name': name, 'description': desc})
+            {'name': name, 'description': desc},
+            session=None)
         self.assertEqual(name, self.test_obj.name)
         self.assertEqual(name, self.test_obj.data['name'])
         self.assertEqual(desc, self.test_obj.data['description'])
@@ -140,7 +146,7 @@ class TestClcNetwork(unittest.TestCase):
         clc_sdk.v2.API.Call = mock.MagicMock()
 
         self.test_obj.Refresh()
-        clc_sdk.v2.Account.GetLocation.assert_called_once_with()
+        clc_sdk.v2.Account.GetLocation.assert_called_once_with(session=None)
 
     def testRefreshCallsGetNetworkWithExpectedArgs(self):
         clc_sdk.v2.Account.GetLocation = mock.MagicMock(return_value="locationlocationlocation")
@@ -149,7 +155,8 @@ class TestClcNetwork(unittest.TestCase):
         self.test_obj.Refresh()
         clc_sdk.v2.API.Call.assert_called_once_with(
             'GET',
-            '/v2-experimental/networks/007/locationlocationlocation/12345')
+            '/v2-experimental/networks/007/locationlocationlocation/12345',
+            session=None)
 
     def testRefreshUpdatesObjectData(self):
         new_name = "UpdatedNetworkName"
@@ -202,7 +209,7 @@ class TestClcNetworks(unittest.TestCase):
         assert clc_sdk.v2.Account.GetAlias.call_count == 1
 
     def testConstructorWithLocation(self):
-        clc_sdk.v2.API.Call.assert_called_once_with('GET','/v2-experimental/networks/007/TST',{})
+        clc_sdk.v2.API.Call.assert_called_once_with('GET','/v2-experimental/networks/007/TST',{}, session=None)
 
     def testConstructorWithNetworkList(self):
         data = [{"networkId": 24601, "accountID": "XYZ", "name": "NAME"}]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -36,13 +36,15 @@ class TestClcServer(unittest.TestCase):
         clc_sdk.v2.API.Call = mock.MagicMock(side_effect=self.get_mock_exception(fail_json={'virus':'very yes'}))
         clc_sdk.v2.Requests = mock.MagicMock()
         self.test_obj._Operation(operation='whatever')
-        clc_sdk.v2.Requests.assert_called_once_with({'virus':'very yes'},alias='base_test')
+        clc_sdk.v2.Requests.assert_called_once_with({'virus':'very yes'},alias='base_test', session=None)
 
     def testOperationHappyPath(self):
         clc_sdk.v2.API.Call = mock.MagicMock()
         clc_sdk.v2.Requests = mock.MagicMock()
         self.test_obj._Operation(operation='whatever')
-        clc_sdk.v2.API.Call.assert_called_once_with('POST','operations/base_test/servers/whatever','["12345"]')
+        clc_sdk.v2.API.Call.assert_called_once_with(
+            'POST', 'operations/base_test/servers/whatever', '["12345"]',
+            session=None)
 
     def testArchive(self):
         self.test_obj._Operation = mock.MagicMock();
@@ -165,7 +167,7 @@ class TestClcServer(unittest.TestCase):
         clc_sdk.v2.Requests = mock.MagicMock()
         clc_sdk.v2.API.Call = mock.MagicMock()
         self.test_obj.Delete()
-        clc_sdk.v2.API.Call.assert_called_once_with('DELETE','servers/base_test/12345')
+        clc_sdk.v2.API.Call.assert_called_once_with('DELETE','servers/base_test/12345', session=None)
 
     # *NIC tests
 
@@ -176,7 +178,8 @@ class TestClcServer(unittest.TestCase):
         clc_sdk.v2.API.Call.assert_called_once_with(
             'POST',
             'servers/base_test/12345/networks',
-            json.dumps({'networkId': 'test_network', 'ipAddress': ''})
+            json.dumps({'networkId': 'test_network', 'ipAddress': ''}),
+            session=None
             )
 
     def test_AddNIC_calls_api_with_provided_ip(self):
@@ -186,7 +189,8 @@ class TestClcServer(unittest.TestCase):
         clc_sdk.v2.API.Call.assert_called_once_with(
             'POST',
             'servers/base_test/12345/networks',
-            json.dumps({'networkId': 'test_network2', 'ipAddress': '1.2.3.4'})
+            json.dumps({'networkId': 'test_network2', 'ipAddress': '1.2.3.4'}),
+            session=None
             )
 
     def test_RemoveNIC_makes_expected_api_call(self):
@@ -194,7 +198,8 @@ class TestClcServer(unittest.TestCase):
         clc_sdk.v2.API.Call = mock.MagicMock()
         self.test_obj.RemoveNIC(network_id='goodbye_network')
         clc_sdk.v2.API.Call.assert_called_once_with(
-            'DELETE', 'servers/base_test/12345/networks/goodbye_network')
+            'DELETE', 'servers/base_test/12345/networks/goodbye_network',
+            session=None)
 
 
     # Static helpers


### PR DESCRIPTION
Hi, I'm David from ElasticBox.

We are integrating the Century Link Cloud in ElasticBox. This PR contains the changes that we need for that integration.

We are interested in actively collaborating with this library, by improving it, adding tests or even adding a system of automatic tests and continuous integration.

We have tried to make the minimal change and to avoid changing the API so all users of this library will continue to work as before.

The changes are:
* We added a new `get_session` in addition to `SetCredentials`. It returns a `session` which contains the token, credentials and other information available as global variables. It doesn't set them in the global namespace.
* Add a session parameter where needed to avoid using the global token for requests.
* Change the unit tests that required it.

The main restriction was to avoid changing the API, so that everybody using this project can update without breaking changes.