### PR TITLE
Use 'json' explicitly for APIv2 _Login instead of rely on the state of clc._REQUESTS_SESSION

### DIFF
--- a/src/clc/APIv2/api.py
+++ b/src/clc/APIv2/api.py
@@ -66,10 +66,11 @@ class API():
 			raise(clc.APIV2NotEnabled)
 
 		session = clc._REQUESTS_SESSION
+		session.headers['content-type'] = "application/json"
 
 		r = session.request("POST",
                             "%s/v2/%s" % (clc.defaults.ENDPOINT_URL_V2,"authentication/login"),
-                            data={"username": clc.v2.V2_API_USERNAME, "password": clc.v2.V2_API_PASSWD},
+                            json={"username": clc.v2.V2_API_USERNAME, "password": clc.v2.V2_API_PASSWD},
                             verify=API._ResourcePath('clc/cacert.pem'))
 
 		if r.status_code == 200:


### PR DESCRIPTION
The question at issue is if you use both APIv1 and APIv, but use APIv1 first:

```
$ cat ./bug.py
#!/usr/bin/python

import clc

clc.v1.SetCredentials("xxxxxxxxxxxxxx","yyyyyyyyyyyy")
clc.v2.SetCredentials("aaa","bbb")

account = "XXX"

DC = "VA1"

servers = clc.v1.Server.GetServers(location=DC, group=None, alias=account)
print clc.v2.Server(servers[0]['Name']).id
```

```
$ ./bug.py
Traceback (most recent call last):
  File "./bug.py", line 14, in <module>
    print clc.v2.Server(servers[0]['Name']).id
  File "/home/user/.local/lib/python2.7/site-packages/clc/APIv2/server.py", line 175, in __init__
    else:  self.alias = clc.v2.Account.GetAlias()
  File "/home/user/.local/lib/python2.7/site-packages/clc/APIv2/account.py", line 41, in GetAlias
    if not clc.ALIAS:  clc.v2.API._Login()
  File "/home/user/.local/lib/python2.7/site-packages/clc/APIv2/api.py", line 80, in _Login
    raise(Exception("Invalid V2 API login.  %s" % (r.json()['message'])))
Exception: Invalid V2 API login.  The request is invalid.
```

If we add any APIv2 call before APIv1 call (e.g. `account = clc.v2.Account.GetAlias()`) - the problem will not manifest itself.

This happens because APIv1 and APIv2 use shared global variable clc._REQUESTS_SESSION (requests.Session() object).
So after we made APIv1 call  - the headers of clc._REQUESTS_SESSION variable contained `'content-type': 'application/json'` header. Then, when we tried to make APIv2 call - it implicitly called `_Login` method and this method passed payload as `x-www-form-urlencoded`, but requests library did not rewrite `content-type` header because it had already been set - https://github.com/kennethreitz/requests/blob/master/requests/models.py#L466.
So the `_Login` code have issue because it sends `x-www-form-urlencoded` data with `application/json` header.

Tests:

```
$ python -m unittest discover
....................................................
----------------------------------------------------------------------
Ran 52 tests in 0.025s

OK
```
