### PR TITLE
Support for BareMetal and Hor.Autoscale. Added timeout to WaitUntilComplete

### DIFF
--- a/src/clc/APIv2/__init__.py
+++ b/src/clc/APIv2/__init__.py
@@ -30,6 +30,7 @@ from clc.APIv2.alert import Alerts, Alert
 from clc.APIv2.queue import Queue, Request, Requests
 from clc.APIv2.anti_affinity import AntiAffinity
 from clc.APIv2.datacenter import Datacenter
+from clc.APIv2.horizontal_autoscale import HorizontalAutoscalePolicy
 from clc.APIv2.api import API
 import clc.APIv2.time_utils
 

--- a/src/clc/APIv2/datacenter.py
+++ b/src/clc/APIv2/datacenter.py
@@ -51,6 +51,7 @@ class Datacenter:
 		"""
 
 		self.deployment_capabilities = None
+		self.baremetal_capabilities = None
 		self.session = session
 
 		if alias:
@@ -110,6 +111,17 @@ class Datacenter:
 				session=self.session)
 
 		return(self.deployment_capabilities)
+
+
+	def BareMetalCapabilities(self,cached=True):
+		if self._DeploymentCapabilities()['supportsBareMetalServers']:
+			if not self.baremetal_capabilities or not cached:
+				self.baremetal_capabilities = clc.v2.API.Call(
+					'GET',
+					'datacenters/%s/%s/bareMetalCapabilities' % (self.alias,self.location),
+					session=self.session)
+
+		return(self.baremetal_capabilities)
 
 
 	def Networks(self, forced_load=False):

--- a/src/clc/APIv2/group.py
+++ b/src/clc/APIv2/group.py
@@ -192,6 +192,35 @@ class Group(object):
 		return(Groups(alias=self.alias,groups_lst=self.data['groups'],session=self.session))
 
 
+	def HorizontalAutoscale(self):
+		group_policy = clc.v2.API.Call(
+			'GET',
+			'groups/%s/%s/horizontalAutoscalePolicy' % (self.alias, self.id),
+			{},
+			session=self.session)
+
+		if group_policy:
+			return clc.v2.HorizontalAutoscalePolicy(group_policy['policyId'], alias=self.alias, session=self.session)
+
+
+	def ApplyHorizontalAutoscale(self, policy_id):
+		return clc.v2.API.Call(
+			'PUT',
+			'groups/%s/%s/horizontalAutoscalePolicy' % (self.alias, self.id),
+			{'policyId': policy_id},
+			session=self.session
+		)
+
+
+	def RemoveHorizontalAutoscale(self):
+		return clc.v2.API.Call(
+			'DELETE',
+			'groups/%s/%s/horizontalAutoscalePolicy' % (self.alias, self.id),
+			{},
+			session=self.session
+		)
+
+
 	def Servers(self):
 		"""Returns a Servers object containing all servers within the group.
 

--- a/src/clc/APIv2/horizontal_autoscale.py
+++ b/src/clc/APIv2/horizontal_autoscale.py
@@ -1,0 +1,101 @@
+"""
+HorizontalAutoscale related functions.
+
+"""
+
+import clc
+import json
+
+
+class HorizontalAutoscalePolicy(object):
+
+    def __init__(self, id_, policy_obj=None, alias=None, session=None):
+        self.id = id_
+        self.dirty = False
+        self.session = session
+
+        if alias:
+            self.alias = alias
+        else:
+            self.alias = clc.v2.Account.GetAlias(session=self.session)
+
+        if policy_obj:
+            self.data = policy_obj
+        else:
+            try:
+                self.Refresh()
+            except clc.APIFailedResponse as e:
+                if e.response_status_code == 404:
+                    raise(clc.CLCException("Horizontal Autoscale Policy does not exist"))
+
+    @staticmethod
+    def GetAll(alias=None, session=None):
+        if not alias:
+            alias = clc.v2.Account.GetAlias(session=session)
+
+        policies = []
+        policies_lst = clc.v2.API.Call('GET', 'horizontalAutoscalePolicies/%s' % alias, {}, session=session)
+        for policy in policies_lst['items']:
+            policies.append(HorizontalAutoscalePolicy(policy['id'], policy, alias=alias, session=session))
+
+        return policies
+
+    @staticmethod
+    def Create(policy_obj, alias=None, session=None):
+        if not alias:
+            alias = clc.v2.Account.GetAlias(session=session)
+
+        policy = clc.v2.API.Call(
+            'POST',
+            'horizontalAutoscalePolicies/%s' % alias,
+            json.dumps(policy_obj),
+            session=session
+        )
+
+        return HorizontalAutoscalePolicy(policy['id'], policy, alias=alias, session=session)
+
+    def Refresh(self):
+        self.dirty = False
+        self.data = clc.v2.API.Call(
+            'GET',
+            'horizontalAutoscalePolicies/%s/%s' % (self.alias, self.id),
+            {},
+            session=self.session
+        )
+
+    def Update(self, policy_obj):
+        self.data = clc.v2.API.Call(
+            'PUT',
+            'horizontalAutoscalePolicies/%s/%s' % (self.alias, self.id),
+            json.dumps(policy_obj),
+            session=self.session
+        )
+
+    def Delete(self):
+        self.dirty = True
+        return clc.v2.API.Call(
+            'DELETE',
+            'horizontalAutoscalePolicies/%s/%s' % (self.alias, self.id),
+            {},
+            session=self.session
+        )
+
+    def ApplyToGroup(self, group_id):
+        return clc.v2.API.Call(
+            'PUT',
+            'groups/%s/%s/horizontalAutoscalePolicy' % (self.alias, group_id),
+            {"policyId": self.id},
+            session=self.session
+        )
+
+    @staticmethod
+    def RemoveFromGroup(group_id, alias=None, session=None):
+        if not alias:
+            alias = clc.v2.Account.GetAlias(session=session)
+
+        return clc.v2.API.Call(
+            'DELETE',
+            'groups/%s/%s/horizontalAutoscalePolicy' % (alias, group_id),
+            {},
+            session=session
+        )

--- a/src/clc/APIv2/server.py
+++ b/src/clc/APIv2/server.py
@@ -595,40 +595,22 @@ class Server(object):
 		# TODO - validate addition_disks path not in template reserved paths
 		# TODO - validate antiaffinity policy id set only with type=hyperscale
 
-		if type == 'bareMetal':
-			return clc.v2.Requests(
-				clc.v2.API.Call(
-					'POST',
-					'servers/%s' % (alias),
-					json.dumps({
-						'name': name,
-						'description': description,
-						'groupId': group_id,
-						'primaryDNS': primary_dns,
-						'secondaryDNS': secondary_dns,
-						'networkId': network_id,
-						'password': password,
-						'type': type,
-						'customFields': custom_fields,
-						'configurationId': configuration_id,
-						'osType': template
-					}),
-					session=session
-				),
-				alias=alias,
-				session=session)
+		payload = {
+			'name': name, 'description': description, 'groupId': group_id, 'primaryDNS': primary_dns, 'secondaryDNS': secondary_dns,
+			'networkId': network_id, 'password': password, 'type': type, 'customFields': custom_fields
+		}
 
+		if type == 'bareMetal':
+			payload.update({'configurationId': configuration_id, 'osType': template})
 		else:
-			return(clc.v2.Requests(clc.v2.API.Call('POST','servers/%s' % (alias),
-					json.dumps({'name': name, 'description': description, 'groupId': group_id, 'sourceServerId': template,
-								'isManagedOS': managed_os, 'primaryDNS': primary_dns, 'secondaryDNS': secondary_dns,
-								'networkId': network_id, 'ipAddress': ip_address, 'password': password,
-								'sourceServerPassword': source_server_password, 'cpu': cpu, 'cpuAutoscalePolicyId': cpu_autoscale_policy_id,
-								'memoryGB': memory, 'type': type, 'storageType': storage_type, 'antiAffinityPolicyId': anti_affinity_policy_id,
-								'customFields': custom_fields, 'additionalDisks': additional_disks, 'ttl': ttl, 'packages': packages}),
-							session=session),
-					alias=alias,
-					session=session))
+			payload.update({'sourceServerId': template, 'isManagedOS': managed_os, 'ipAddress': ip_address,
+				'sourceServerPassword': source_server_password, 'cpu': cpu, 'cpuAutoscalePolicyId': cpu_autoscale_policy_id,
+				'memoryGB': memory, 'storageType': storage_type, 'antiAffinityPolicyId': anti_affinity_policy_id,
+				'additionalDisks': additional_disks, 'ttl': ttl, 'packages': packages})
+
+		return clc.v2.Requests(clc.v2.API.Call('POST','servers/%s' % (alias), json.dumps(payload), session=session),
+							   alias=alias,
+							   session=session)
 
 
 	def Clone(self,network_id,name=None,cpu=None,memory=None,group_id=None,alias=None,password=None,ip_address=None,

--- a/src/clc/APIv2/time_utils.py
+++ b/src/clc/APIv2/time_utils.py
@@ -24,6 +24,10 @@ def SecondsToZuluTS(secs=None):
 	return(datetime.utcfromtimestamp(secs).strftime("%Y-%m-%dT%H:%M:%SZ"))
 
 
+def TimeoutExpired(start_time, timeout):
+	return timeout and (time.time() - start_time) > timeout
+
+
 
 if __name__ == "__main__":
 	now = int(time.time())

--- a/src/clc/__init__.py
+++ b/src/clc/__init__.py
@@ -72,4 +72,7 @@ class InvalidAPIResponseException(CLCException):
     pass
 class APIFailedResponse(CLCException):
 	pass
-
+class RequestTimeoutException(CLCException):
+    def __init__(self, message, status):
+        super(RequestTimeoutException, self).__init__(message)
+        self.status = status


### PR DESCRIPTION
Hi, I'm Efren from ElasticBox team (CenturyLink).

We had included in ElasticBox support for BareMetal servers and Horizontal Autoscaling, and we would like include that functionality in the CLC Python library.

This PR include the following changes:
- Added `BareMetalCapabilities` method to `Datacenter` class.
- Added some methods in `Group` class to retrieve the Horizontal Autoscaling policy currently applied, apply a new one, or remove existing applied.
- Added a new `HorizontalAutoscalePolicy` class, with methods to list, create, delete, update, apply to group and remove from group.
- Added an optional timeout parameter on `WaitUntilComplete` method, because in case of a failure in CLC the loop would never ends.
- Updated `Create` method on `Server` class to support BareMetal servers creation.

Thanks.
