### PR TITLE
Fix. KeyError was raised when operation not queued and not error msg

### DIFF
--- a/src/clc/APIv2/queue.py
+++ b/src/clc/APIv2/queue.py
@@ -84,7 +84,7 @@ class Requests(object):
 					self.requests.append(Request([obj['id'] for obj in r['links'] if obj['rel']=='status'][0],
 				                             alias=self.alias,request_obj={'context_key': context_key, 'context_val': context_val},
 											 session=self.session))
-			else:
+			elif 'errorMessage' in r:
 				# If we're dealing with a list of responses and we have an error with one I'm not sure how
 				# folks would expect this to behave.  If server is already in desired state thus the request
 				# fails that shouldn't be an exception.  If we're running against n tasks and just one has an


### PR DESCRIPTION
@ack 

Fix for issue: https://github.com/CenturyLinkCloud/clc-python-sdk/issues/41

When Server is already in the desired state, the Server operation is not queued and there is no error message. We should pass in this case and don't raise exception.