### PR TITLE
Fix request object for server creation with short clc alias

### DIFF
--- a/src/clc/APIv2/queue.py
+++ b/src/clc/APIv2/queue.py
@@ -63,7 +63,7 @@ class Requests(object):
 
 		for r in requests_lst:
 
-			if 'server' in r and len(r['server'])<=6:
+			if 'server' in r and len(r['server'])<=8:
 				# Hopefully this captures only new server builds, TODO find a better way to ID these
 				for link in r['links']:
 					if re.search("/v2/servers/",link['href']):


### PR DESCRIPTION
@davisein @cristb 

The code was assuming that CLC Alias has at least 4 characters. But it could be of 3 or 2 chars only.